### PR TITLE
Allow simple XHR requests

### DIFF
--- a/lib/corsproxy.js
+++ b/lib/corsproxy.js
@@ -9,12 +9,6 @@ httpProxy = require('http-proxy');
 
 module.exports = function(req, res, proxy) {
   var cors_headers, header, headers, host, hostname, ignore, key, path, port, target, target0, value, _i, _len, _ref, _ref1, _ref2;
-  if (!req.headers.origin) {
-    console.log('req.headers.origin not given');
-    res.write('hello https\n');
-    res.end();
-    return;
-  }
   if (req.headers['access-control-request-headers']) {
     headers = req.headers['access-control-request-headers'];
   } else {
@@ -32,7 +26,7 @@ module.exports = function(req, res, proxy) {
     'access-control-max-age': '86400',
     'access-control-allow-headers': headers,
     'access-control-allow-credentials': 'true',
-    'access-control-allow-origin': req.headers.origin
+    'access-control-allow-origin': req.headers.origin || '*'
   };
   if (req.method === 'OPTIONS') {
     console.log('responding to OPTIONS request');

--- a/src/corsproxy.coffee
+++ b/src/corsproxy.coffee
@@ -4,14 +4,8 @@ httpProxy = require('http-proxy');
 
 
 module.exports = (req, res, proxy) ->
-  
-  unless req.headers.origin
-    console.log 'req.headers.origin not given'
-    res.write('hello https\n');
-    res.end();
-    return
-  
-    
+
+
   if req.headers['access-control-request-headers']
     headers = req.headers['access-control-request-headers']
   else
@@ -23,15 +17,15 @@ module.exports = (req, res, proxy) ->
     'access-control-max-age'           : '86400' # 24 hours
     'access-control-allow-headers'     : headers
     'access-control-allow-credentials' : 'true'
-    'access-control-allow-origin'      : req.headers.origin
-  
-  
+    'access-control-allow-origin'      : req.headers.origin || '*'
+
+
   if req.method is 'OPTIONS'
     console.log 'responding to OPTIONS request'
     res.writeHead(200, cors_headers);
     res.end();
     return
-    
+
   else
     # Handle CORS proper.
 
@@ -60,12 +54,12 @@ module.exports = (req, res, proxy) ->
       return;
 
     # console.log "proxying to #{target.host}:#{target.port}#{path}"
-    
-    
+
+
     res.setHeader(key, value) for key, value of cors_headers
-    
+
     # req.headers.host = hostname
     req.url          = path
-    
+
     # Put your custom server logic here, then proxy
     proxy.proxyRequest(req, res, target);


### PR DESCRIPTION
The server was failing with `req.headers.origin not given` for certain simple AJAX GET requests. I don't think Chrome sets the Origin header for simple GET requests without `withCredentials` set. 

This change makes such requests succeed.
