### PR TITLE
Allow requests without the Origin header set.

### DIFF
--- a/lib/corsproxy.js
+++ b/lib/corsproxy.js
@@ -9,12 +9,6 @@ httpProxy = require('http-proxy');
 
 module.exports = function(req, res, proxy) {
   var cors_headers, header, headers, host, hostname, ignore, key, path, port, target, target0, value, _i, _len, _ref, _ref1, _ref2;
-  if (!req.headers.origin) {
-    console.log('req.headers.origin not given');
-    res.write('hello https\n');
-    res.end();
-    return;
-  }
   if (req.headers['access-control-request-headers']) {
     headers = req.headers['access-control-request-headers'];
   } else {
@@ -32,7 +26,7 @@ module.exports = function(req, res, proxy) {
     'access-control-max-age': '86400',
     'access-control-allow-headers': headers,
     'access-control-allow-credentials': 'true',
-    'access-control-allow-origin': req.headers.origin
+    'access-control-allow-origin': req.headers.origin || '*'
   };
   if (req.method === 'OPTIONS') {
     console.log('responding to OPTIONS request');

--- a/src/corsproxy.coffee
+++ b/src/corsproxy.coffee
@@ -4,13 +4,6 @@ httpProxy = require('http-proxy');
 
 
 module.exports = (req, res, proxy) ->
-  
-  unless req.headers.origin
-    console.log 'req.headers.origin not given'
-    res.write('hello https\n');
-    res.end();
-    return
-  
     
   if req.headers['access-control-request-headers']
     headers = req.headers['access-control-request-headers']
@@ -23,7 +16,7 @@ module.exports = (req, res, proxy) ->
     'access-control-max-age'           : '86400' # 24 hours
     'access-control-allow-headers'     : headers
     'access-control-allow-credentials' : 'true'
-    'access-control-allow-origin'      : req.headers.origin
+    'access-control-allow-origin'      : req.headers.origin || '*'
   
   
   if req.method is 'OPTIONS'


### PR DESCRIPTION
Chrome does not always set the Origin header for every XMLHttpRequest.

Replaces pull request #6.
