### PR TITLE
Small readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,7 @@ With custom target:
     var cors_proxy = require("corsproxy");
     var http_proxy = require("http-proxy");
     cors_proxy.options = {
-        target: {
-            host:"0.0.0.0",
-            port:5984
-        }
+         target: "http://0.0.0.0:5984"
     };
     http_proxy.createServer(cors_proxy).listen(1234);
 


### PR DESCRIPTION
i did some debugging and found that the lib/corsproxy.js seems to expect a well formed url instead of an object, probably just a change in the code that needed to be reflected in the readme

target0 = url.parse(module.exports.options.target);
