### PR TITLE
'Host' request header fixed

### DIFF
--- a/bin/corsproxy
+++ b/bin/corsproxy
@@ -35,6 +35,7 @@ server.route({
       mapUri: function(request, callback) {
         request.host = request.params.host
         request.path = request.path.substr(request.params.host.length + 1)
+        request.headers['host'] = request.host; 
         console.log('proxy to http://' + request.host + request.path)
         callback(null, 'http://' + request.host + request.path, request.headers);
       }


### PR DESCRIPTION
Some servers return "400 Bad Request" on requests with "Host: localhost:1337". This pull request will set target hostname as a value for "Host" header.

(_second try from the clean fork repo_)