### PR TITLE
Set Access-Control-Allow-Origin to "*" if request has no Origin

### DIFF
--- a/lib/add-cors-headers.js
+++ b/lib/add-cors-headers.js
@@ -31,7 +31,7 @@ module.exports = function addCorsHeaders (request, reply) {
     }
   }
 
-  response.headers['access-control-allow-origin'] = request.headers.origin
+  response.headers['access-control-allow-origin'] = request.headers.origin || "*"
   response.headers['access-control-allow-headers'] = allowedHeaders.join(', ')
   response.headers['access-control-expose-headers'] = 'content-type, content-length, etag'
   response.headers['access-control-allow-methods'] = 'GET, PUT, POST, DELETE'


### PR DESCRIPTION
Previously it would include the header:
Access-Control-Allow-Origin: undefined