### PR TITLE
add host as a custom parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 npm install -g corsproxy
 corsproxy
 # with custom port: CORSPROXY_PORT=1234 corsproxy
+# with custom host: CORSPROXY_HOST=localhost corsproxy
 # with debug server: DEBUG=1 corsproxy
 ```
 

--- a/bin/corsproxy
+++ b/bin/corsproxy
@@ -8,7 +8,7 @@ var loggerOptions = require('../lib/logger-options')
 var server = new Hapi.Server({})
 var port = parseInt(process.env.CORSPROXY_PORT || process.env.PORT || 1337, 10)
 
-var proxy = server.connection({ port: port, labels: ['proxy'] })
+var proxy = server.connection({ port: port, labels: ['proxy'], (process.env.CORSPROXY_HOST || 'localhost') })
 
 server.register(require('inert'), function () {})
 server.register(require('h2o2'), function () {})

--- a/bin/corsproxy
+++ b/bin/corsproxy
@@ -7,8 +7,8 @@ var loggerOptions = require('../lib/logger-options')
 
 var server = new Hapi.Server({})
 var port = parseInt(process.env.CORSPROXY_PORT || process.env.PORT || 1337, 10)
-
-var proxy = server.connection({ port: port, labels: ['proxy'], (process.env.CORSPROXY_HOST || 'localhost') })
+var host = (process.env.CORSPROXY_HOST || 'localhost');
+var proxy = server.connection({ port: port, labels: ['proxy'], host: host})
 
 server.register(require('inert'), function () {})
 server.register(require('h2o2'), function () {})

--- a/bin/corsproxy
+++ b/bin/corsproxy
@@ -65,7 +65,7 @@ proxy.route({
 
 if (process.env.DEBUG) {
   var testport = port + 1
-  var test = server.connection({ port: testport, labels: ['test'] })
+  var test = server.connection({ port: testport, labels: ['test'], host: host })
 
   server.register(require('vision'), function (error) {
     if (error) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "corsproxy",
-  "version": "0.0.2",
   "description": "standalone CORS proxy",
   "main": "./index.js",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corsproxy",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "standalone CORS proxy",
   "main": "./index.js",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "corsproxy",
+  "version": "0.0.1",
   "description": "standalone CORS proxy",
   "main": "./index.js",
   "author": {


### PR DESCRIPTION
Hello, i think your corsproxy is really usefull, but in my case it didn't open the host as lohalhost but with myy ubuntu user. I guess is because of hapi. So I add a parameter to allow me to configure as well the host. Thank you