### PR TITLE
add CORSPROXY_MAX_PAYLOAD option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ cache:
 notifications:
   email: false
 node_js:
-  - '4'
+  - '6'
 before_install:
-  - npm i -g npm@^2.0.0
+  - npm i -g npm@^3.0.0
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
 script: TEST_CLIENT=selenium:firefox npm test

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ corsproxy
 # with custom port: CORSPROXY_PORT=1234 corsproxy
 # with custom host: CORSPROXY_HOST=localhost corsproxy
 # with debug server: DEBUG=1 corsproxy
+# with custom payload max bytes set to 10MB (1MB by default): CORSPROXY_MAX_PAYLOAD=10485760 corsproxy
 ```
 
 ## Usage

--- a/bin/corsproxy
+++ b/bin/corsproxy
@@ -116,5 +116,5 @@ if (process.env.DEBUG) {
 server.start(function (error) {
   if (error) server.log('error', error)
 
-  server.log('info', 'CORS Proxy running at: ' + server.info.uri)
+  server.log('info', 'CORS Proxy running at: ' + proxy.info.uri)
 })

--- a/bin/corsproxy
+++ b/bin/corsproxy
@@ -8,6 +8,7 @@ var loggerOptions = require('../lib/logger-options')
 var server = new Hapi.Server({})
 var port = parseInt(process.env.CORSPROXY_PORT || process.env.PORT || 1337, 10)
 var host = (process.env.CORSPROXY_HOST || 'localhost');
+var maxPayload = parseInt(process.env.CORSPROXY_MAX_PAYLOAD || 1048576, 10)
 var proxy = server.connection({ port: port, labels: ['proxy'], host: host})
 
 server.register(require('inert'), function () {})
@@ -43,6 +44,11 @@ proxy.route({
         console.log('proxy to http://' + request.host + request.path)
         callback(null, 'http://' + request.host + request.path + query, request.headers)
       }
+    }
+  },
+  config: {
+    payload: {
+      maxBytes: maxPayload
     }
   }
 })


### PR DESCRIPTION
hapi has a max payload bytes setting defaults to 1MB, it causes issue (400 Bad Request) if we want to send more payload data through the proxy. This pull request adds an option `CORSPROXY_MAX_PAYLOAD` to make it configurable.