### PR TITLE
Add instructions to run with different hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ To access another domain, use the domain name (including port) as the first fold
 - http://localhost:1337/my.domain.com/path/to/resource
 - etc etc
 
+By default the cors proxy will only answer requests sent to localhost. To use another domain (e.g. machine name) set an enviroment variable CORSPROXY_HOST to the required value before launching.
+
 ## License
 
 MIT


### PR DESCRIPTION
I was using this but was unable to get it working from a different machine. I found the answer was to set CORSPROXY_HOST by looking at the source code. This isn't documented anywhere but I think it is a common enough usage to require explanation. This would have saved me some time.