### PR TITLE
Add docker alternative

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:8
+
+RUN npm install -g corsproxy
+
+EXPOSE 1337
+
+ENV CORSPROXY_HOST 0.0.0.0
+
+ENTRYPOINT ["corsproxy"]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ corsproxy
 # with custom payload max bytes set to 10MB (1MB by default): CORSPROXY_MAX_PAYLOAD=10485760 corsproxy
 ```
 
+### Docker
+
+It is also possible to run the cors proxy in a docker container:
+
+```
+# Build image
+docker build -t corsproxy .
+
+# Run container
+docker run -p 1337:1337 --name corsproxy -d corsproxy
+```
+
 ## Usage
 
 The cors proxy will start at http://localhost:1337.


### PR DESCRIPTION
I've added a Dockerfile to build and run the cors proxy in a container. So it is not necessary to have Node installed on the local machine.